### PR TITLE
Chore: Add `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ ignore = [
     "PLR0912", # too-many-branches
     "PLR0913", # too-many-arguments
     "PLR0915", # too-many-statements
+
+    "S101", # assert
+    "T201", # print
 ]
 
 [tool.ruff.lint.pycodestyle]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,11 +56,3 @@ ignore-overlong-task-comments = true
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-
-# Temporary
-[tool.ruff.lint.flake8-quotes]
-inline-quotes = "single"
-
-# Temporary
-[tool.ruff.format]
-quote-style = "single"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "jsonschema>=4.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,66 @@
+[project]
+name = "majsoul-liqi-json"
+version = "0.1.0"
+description = "Generate .proto file from MahjongSoul liqi.json"
+authors = [
+    { name = "Cryolite", email = "cryolite.indigo@gmail.com" },
+]
+license = { text = "MIT License" }
+readme = "README.md"
+requires-python = ">=3.12"
+classifiers = [
+    "Private :: Do Not Upload",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "jsonschema>=4.23.0",
+]
+
+[project.urls]
+Repository = "https://github.com/Cryolite/majsoul-liqi-json.git"
+
+[tool.uv]
+package = false
+dev-dependencies = [
+    "mypy>=1.12.1,<2",
+    "ruff>=0.7.0,<0.8",
+    "types-jsonschema>=4.23.0.20240813",
+]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 79
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+    "D", # pydocstyle
+
+    "ANN002",  # missing-type-args
+    "ANN003",  # missing-type-kwargs
+    "ANN101",  # missing-type-self
+    "ANN102",  # missing-type-cls
+    "TD002",   # missing-todo-author
+    "TD003",   # missing-todo-link
+    "PLR0911", # too-many-return-statements
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "PLR0915", # too-many-statements
+]
+
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 72
+ignore-overlong-task-comments = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+# Temporary
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+
+# Temporary
+[tool.ruff.format]
+quote-style = "single"


### PR DESCRIPTION
`pyproject.toml` を追加します。

- `version` は uv で生成した際のデフォルトである `0.1.0` としています。
- `description` は GitHub の About からコピーしました。
- `authors` は kanachan v2 からコピーしました。
- `requires-python` は ubuntu noble (24.04) のデフォルトである 3.12 以上としています。
- 本プロジェクトはパッケージではないため、`[tool.uv]` の `package` は `false` としています。
- Ruff の設定は majsoulrpa から持ってきています。

`pyproject.toml` の devcontainer や `Dockerfile` での利用は別の PR に分けます。