### PR TITLE
docs: Add third-party notices

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ Dockerfile*
 
 LICENSE
 README.md
+THIRD-PARTY-NOTICES.md
 
 .devcontainer
 .vscode

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,37 @@
+# NOTICES AND INFORMATION
+
+majsoul-liqi-json uses third-party libraries or other resources that may be
+distributed under licenses different than the majsoul-liqi-json software.
+
+In the event that we accidentally failed to list a required notice, please
+bring it to our attention by posting an issue.
+
+The attached notices are provided for information only.
+
+## jsonschema
+
+**Source**: <https://github.com/python-jsonschema/jsonschema>
+
+**License**:
+
+```text
+Copyright (c) 2013 Julian Berman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+```


### PR DESCRIPTION
使用している OSS ライブラリの利用条件を遵守するため、ライセンスの告知ファイルを追加します。
形式は以下を参考にしています。

- 全体の形式
[microsoft/terminal/NOTICE.md](https://github.com/microsoft/terminal/blob/main/NOTICE.md)

- 前書き・ファイル名
[dotnet/runtime/THIRD-PARTY-NOTICES.TXT](https://github.com/dotnet/runtime/blob/main/THIRD-PARTY-NOTICES.TXT)