### PR TITLE
chore: Update dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,6 @@ ignore = [
 
     "ANN002",  # missing-type-args
     "ANN003",  # missing-type-kwargs
-    "ANN101",  # missing-type-self
-    "ANN102",  # missing-type-cls
     "TD002",   # missing-todo-author
     "TD003",   # missing-todo-link
     "PLR0911", # too-many-return-statements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ Repository = "https://github.com/Cryolite/majsoul-liqi-json.git"
 package = false
 dev-dependencies = [
     "mypy>=1.12.1,<2",
-    "ruff>=0.7.0,<0.8",
+    "ruff>=0.14.10,<0.15",
     "types-jsonschema>=4.23.0.20240813",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ Repository = "https://github.com/Cryolite/majsoul-liqi-json.git"
 [tool.uv]
 package = false
 dev-dependencies = [
-    "mypy>=1.12.1,<2",
+    "mypy>=1.19.1,<2",
     "ruff>=0.14.10,<0.15",
     "types-jsonschema>=4.23.0.20240813",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,13 +22,21 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/Cryolite/majsoul-liqi-json.git"
 
-[tool.uv]
-package = false
-dev-dependencies = [
-    "mypy>=1.19.1,<2",
+[dependency-groups]
+dev = [
+    { include-group = "lint" },
+    { include-group = "typing" },
+]
+lint = [
     "ruff>=0.14.10,<0.15",
+]
+typing = [
+    "mypy>=1.19.1,<2",
     "types-jsonschema>=4.23.0.20240813",
 ]
+
+[tool.uv]
+package = false
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
- Ruff を最新版にアップデートします。また、最新版では削除されている設定の `ANN101` (missing-type-self) , `ANN102` (missing-type-cls) を `tool.ruff.lint.ignore` から削除します。
- mypy を最新版にアップデートします。
- 開発依存関係の宣言を非推奨になった `tool.uv.dev-dependencies` から Python 標準の `[dependency-groups]` に移動します。